### PR TITLE
Fix/bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -37,9 +37,16 @@ alias rmi='rm -i'
 alias cpi='cp -i'
 alias mvi='mv -i'
 
+# Python alias
+alias python="python3"
+alias pip="pip3"
+
+# ----------
+# PATH
+# ----------
 # PATH of JAVA_HOME
-# export JAVA_HOME=$(/usr/libexec/java_home)
-# export SBT_OPTS="-Xms2048m -Xmx2048m -Xss10M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:ReservedCodeCacheSize=128m -XX:MaxMetaspaceSize=256m"
+export JAVA_HOME=$(/usr/libexec/java_home)
+export SBT_OPTS="-Xms2048m -Xmx2048m -Xss10M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:ReservedCodeCacheSize=128m -XX:MaxMetaspaceSize=256m"
 
 # Node PATH
-# export PATH=$HOME/.nodebrew/current/bin:$PATH
+export PATH=$HOME/.nodebrew/current/bin:$PATH

--- a/.bashrc
+++ b/.bashrc
@@ -29,12 +29,8 @@ alias l='ls -CF'
 # less tab-size 4
 alias less='less -x4'
 
-# emacs 
-# alias emacs='emacs -nw'
-alias emacs='emacs-26.3 -nw'
-
 # screen (use brew installed screen)
-alias screen='screen-4.8.0'
+# alias screen='screen-4.8.0'
 
 # alias confirm
 alias rmi='rm -i'
@@ -42,8 +38,8 @@ alias cpi='cp -i'
 alias mvi='mv -i'
 
 # PATH of JAVA_HOME
-export JAVA_HOME=$(/usr/libexec/java_home)
-export SBT_OPTS="-Xms2048m -Xmx2048m -Xss10M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:ReservedCodeCacheSize=128m -XX:MaxMetaspaceSize=256m"
+# export JAVA_HOME=$(/usr/libexec/java_home)
+# export SBT_OPTS="-Xms2048m -Xmx2048m -Xss10M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:ReservedCodeCacheSize=128m -XX:MaxMetaspaceSize=256m"
 
 # Node PATH
-export PATH=$HOME/.nodebrew/current/bin:$PATH
+# export PATH=$HOME/.nodebrew/current/bin:$PATH

--- a/.bashrc
+++ b/.bashrc
@@ -41,6 +41,9 @@ alias mvi='mv -i'
 alias python="python3"
 alias pip="pip3"
 
+# emacs No Window mode
+alias enw="emacs -nw"
+
 # ----------
 # PATH
 # ----------
@@ -50,3 +53,19 @@ export SBT_OPTS="-Xms2048m -Xmx2048m -Xss10M -XX:+UseConcMarkSweepGC -XX:+CMSCla
 
 # Node PATH
 export PATH=$HOME/.nodebrew/current/bin:$PATH
+
+# goenv PATH and initialization
+export GOENV_ROOT="$HOME/.goenv"
+export PATH="$GOENV_ROOT/bin:$PATH"
+eval "$(goenv init -)"
+
+# HACK: Go PATH
+# export GOPATH="${HOME}/go"
+export PATH="$GOROOT/bin:$PATH"
+export PATH="$PATH:$GOPATH/bin"
+
+export GO111MODULE=on  # go Module を有効にする
+export GOENV_DISABLE_GOPATH=1  # go get した pkg などを $GOPATH/{version}/pkg ではなく $GOPATH/pkg に配置する
+
+# my scripts PATH
+export PATH=$HOME/mybin:$PATH


### PR DESCRIPTION
新環境に合わせて `.bashrc` を変更
* 採用
  1. emacs no-window mode の alias を追加
  2. goenv / go の PATH を追加
  3. 自作スクリプトファイルへの PATH を追加
  4. python の alias を追加

* 廃止
  - emacs, screen の version 指定の alias を廃止